### PR TITLE
Add a BuildKite build for building against LLVM HEAD

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -31,3 +31,8 @@ tasks:
     name: Rolling Bazel Version With Clang and LLD
     bazel: "rolling"
     <<: *default_linux_task
+  ubuntu2004_llvm_at_head:
+    name: Stable Bazel Version with LLVM at HEAD
+    build_flags:
+      - "--repo_env=LLVM_AT_HEAD=1"
+    <<: *default_linux_task

--- a/bazel/llvm.bzl
+++ b/bazel/llvm.bzl
@@ -46,10 +46,13 @@ def _llvm_loader_repository(repository_ctx):
         )
     else:
         # Use downloaded LLVM built with Bazel
+        llvm_repo = "llvm-raw-head" if "LLVM_AT_HEAD" in repository_ctx.os.environ and repository_ctx.os.environ["LLVM_AT_HEAD"] else "llvm-raw"
         repository_ctx.template(
             "llvm.bzl",
             Label("//bazel:llvm_remote.bzl.tmpl"),
-            substitutions = {},
+            substitutions = {
+                "%{LLVM_REPO}": llvm_repo,
+            },
             executable = False,
         )
 
@@ -64,6 +67,12 @@ def llvm_loader_repository_dependencies():
         shallow_since = "1685492206 -0700",
         remote = "https://github.com/llvm/llvm-project.git",
     )
+    new_git_repository(
+        name = "llvm-raw-head",
+        build_file_content = "# empty",
+        branch = "main",
+        remote = "https://github.com/llvm/llvm-project.git",
+    )
 
 llvm_loader_repository = repository_rule(
     implementation = _llvm_loader_repository,
@@ -73,5 +82,6 @@ llvm_loader_repository = repository_rule(
     },
     environ = [
         "LLVM_INSTALL_PATH",
+        "LLVM_AT_HEAD",
     ],
 )

--- a/bazel/llvm_remote.bzl.tmpl
+++ b/bazel/llvm_remote.bzl.tmpl
@@ -8,7 +8,7 @@
 #   https://github.com/llvm/llvm-project/blob/main/utils/bazel/examples/http_archive/WORKSPACE
 #   https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.0
 
-load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
+load("@%{LLVM_REPO}//utils/bazel:configure.bzl", "llvm_configure")
 
 # Pass through to LLVM's Bazel configuration to create the repository.
 def llvm_repository(name):


### PR DESCRIPTION
This PR is created in GitHub to trigger a BuildKite build and thus test if the BuildKite configuration change is correct. The PR will be reverted (and a changelist will be submitted internally and migrated to GitHub via Copybara) once testing is done.