### PR TITLE
Build rs_bindings_from_cc with Cargo

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,7 +6,7 @@
 default_linux_targets: &default_linux_targets
   # TODO(b/234804076): Make the whole repo buildable/testable with //...
   # Target below is only a rudimentary smoke test.
-  - "//rs_bindings_from_cc:rs_bindings_from_cc_impl"
+  - "//rs_bindings_from_cc:rs_bindings_from_cc_main"
   - "//rs_bindings_from_cc:importer_test"
   - "//rs_bindings_from_cc:cc_collect_instantiations_test"
   - "//rs_bindings_from_cc:collect_instantiations_test"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # avoid trailing `/` because these are symlinks
 /bazel-*
+/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,86 +7,17 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+name = "arc_anyhow"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+]
 
 [[package]]
 name = "cc"
@@ -95,474 +26,214 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "4.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98330784c494e49850cb23b8e2afcca13587d2500b2e3f1f78ae20248059c9be"
+name = "code_gen_utils"
+version = "0.0.0"
 dependencies = [
- "clap_builder",
- "clap_derive",
- "once_cell",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182eb5f2562a67dda37e2c57af64d720a9e010c5e860ed87c056586aeafa52e"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.26",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "direct-cargo-bazel-deps"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "clap",
- "either",
- "flagset",
+ "arc_anyhow",
  "itertools",
- "maplit",
  "once_cell",
- "pin-project",
  "proc-macro2",
  "quote",
- "regex",
- "salsa",
- "serde",
- "serde_json",
- "static_assertions",
- "syn 2.0.26",
- "tempfile",
+ "syn",
  "unicode-ident",
 ]
 
 [[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+name = "collect_instantiations"
+version = "0.0.0"
 dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
+ "arc_anyhow",
+ "ffi_types",
+ "proc-macro2",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+name = "common_sys"
+version = "0.0.0"
+dependencies = [
+ "crubit_build",
+]
+
+[[package]]
+name = "crubit_build"
+version = "0.0.0"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
+name = "either"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "error_report"
+version = "0.0.0"
 dependencies = [
- "instant",
+ "anyhow",
+ "arc_anyhow",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ffi_types"
+version = "0.0.0"
+dependencies = [
+ "arc_anyhow",
+ "serde",
 ]
 
 [[package]]
 name = "flagset"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+name = "generate_bindings"
+version = "0.0.0"
 dependencies = [
- "unicode-segmentation",
+ "anyhow",
+ "arc_anyhow",
+ "code_gen_utils",
+ "error_report",
+ "ffi_types",
+ "flagset",
+ "ir",
+ "itertools",
+ "memoized",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "token_stream_printer",
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+name = "ir"
+version = "0.0.0"
 dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.4",
- "windows-sys 0.48.0",
+ "arc_anyhow",
+ "code_gen_utils",
+ "flagset",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "libc"
-version = "0.2.147"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+name = "lifetime_analysis_sys"
+version = "0.0.0"
 dependencies = [
- "autocfg",
- "scopeguard",
+ "crubit_build",
 ]
 
 [[package]]
-name = "log"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+name = "lifetime_annotations_sys"
+version = "0.0.0"
+dependencies = [
+ "crubit_build",
+]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+name = "memoized"
+version = "0.0.0"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "oorandom"
-version = "11.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.26",
-]
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+name = "rs_bindings_from_cc"
+version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "rs_bindings_from_cc_sys",
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+name = "rs_bindings_from_cc_sys"
+version = "0.0.0"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.36.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
-dependencies = [
- "bitflags 2.3.3",
- "errno",
- "libc",
- "linux-raw-sys 0.4.3",
- "windows-sys 0.48.0",
+ "collect_instantiations",
+ "common_sys",
+ "crubit_build",
+ "generate_bindings",
+ "lifetime_analysis_sys",
+ "lifetime_annotations_sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "salsa"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b84d9f96071f3f3be0dc818eae3327625d8ebc95b58da37d6850724f31d3403"
-dependencies = [
- "crossbeam-utils",
- "indexmap",
- "lock_api",
- "log",
- "oorandom",
- "parking_lot",
- "rustc-hash",
- "salsa-macros",
- "smallvec",
-]
-
-[[package]]
-name = "salsa-macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3904a4ba0a9d0211816177fd34b04c7095443f8cdacd11175064fe541c8fe2"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -570,28 +241,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -599,212 +252,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+name = "token_stream_printer"
+version = "0.0.0"
 dependencies = [
+ "anyhow",
  "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix 0.36.15",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[workspace]
+members = [
+  "rs_bindings_from_cc/cargo/rs_bindings_from_cc",
+]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here are some resources for getting started with Crubit:
 $ apt install clang lld bazel
 $ git clone git@github.com:google/crubit.git
 $ cd crubit
-$ bazel build --linkopt=-fuse-ld=/usr/bin/ld.lld //rs_bindings_from_cc:rs_bindings_from_cc_impl
+$ bazel build --linkopt=-fuse-ld=/usr/bin/ld.lld //rs_bindings_from_cc:rs_bindings_from_cc_main
 ```
 
 ### Using a prebuilt LLVM tree
@@ -65,5 +65,5 @@ $ cmake --build build -j
 $ # wait...
 $ cmake --install build
 $ cd ../crubit
-$ LLVM_INSTALL_PATH=../llvm-project/install bazel build //rs_bindings_from_cc:rs_bindings_from_cc_impl
+$ LLVM_INSTALL_PATH=../llvm-project/install bazel build //rs_bindings_from_cc:rs_bindings_from_cc_main
 ```

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -1,0 +1,13 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "crubit_build"
+edition = "2021"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+cc = "1"

--- a/build/absl.rs
+++ b/build/absl.rs
@@ -1,0 +1,54 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+const LIB_EXTENSION: &str = "a";
+#[cfg(windows)]
+const LIB_EXTENSION: &str = "lib";
+
+/// Returns the path to the absl libraries (to be used as a search path) and a
+/// list of libraries to be linked.
+pub fn collect_absl_libs() -> (PathBuf, Vec<OsString>) {
+    assert!(cfg!(unix) || cfg!(windows));
+
+    let absl_lib_dir = Path::new(&std::env::var_os("ABSL_LIB_DIR").expect("ABSL_LIB_DIR must be specified in the environment")).to_owned();
+
+    let mut libs = Vec::new();
+
+    for f in std::fs::read_dir(&absl_lib_dir).expect("unable to read ABSL_LIB_DIR") {
+        let Ok(entry) = f else { continue };
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        };
+        let path = entry.path();
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+        if ext != LIB_EXTENSION {
+            continue;
+        }
+        let libname = if cfg!(windows) {
+            // On windows, the full filename: `name.lib`.
+            let Some(filename) = path.file_name() else {
+                continue;
+            };
+            filename.to_str().expect("absl lib has non-utf8 name")
+        } else {
+            // On unix, drop the lib prefix and the extension: `libname.a` => `name`.
+            let Some(stem) = path.file_stem() else {
+                continue;
+            };
+            let s = stem.to_str().expect("absl lib has non-utf8 name");
+            s.strip_prefix("lib").unwrap_or(s)
+        };
+        libs.push(OsStr::new(libname).to_owned())
+    }
+    libs.sort_unstable();
+
+    (absl_lib_dir, libs)
+}

--- a/build/clang.rs
+++ b/build/clang.rs
@@ -1,0 +1,77 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+#[cfg(unix)]
+const LIB_EXTENSION: &str = "a";
+#[cfg(windows)]
+const LIB_EXTENSION: &str = "lib";
+
+fn include_lib(libname: &str) -> bool {
+    if libname.ends_with("Main") {
+        return false;
+    }
+    // Skip target backends.
+    if libname.starts_with("LLVMX86")
+        || libname.starts_with("LLVMWebAssem")
+        || libname.starts_with("LLVMRISCV")
+        || libname.starts_with("LLVMMips")
+        || libname.starts_with("LLVMLoongArch")
+        || libname.starts_with("LLVMARM")
+        || libname.starts_with("LLVMAArch")
+    {
+        return false;
+    }
+    if libname.contains("clangd") || libname.contains("clangTidy") {
+        return false;
+    }
+    if libname.starts_with("lld") {
+        return false;
+    }
+    true
+}
+
+/// Returns a list of all clang and llvm libraries to be linked.
+pub fn collect_clang_libs(lib_dir: &Path) -> Vec<OsString> {
+    assert!(cfg!(unix) || cfg!(windows));
+
+    let mut libs = Vec::new();
+
+    for f in std::fs::read_dir(&lib_dir).expect(&format!("unable to read {}", lib_dir.display())) {
+        let Ok(entry) = f else { continue };
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        };
+        let path = entry.path();
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+        if ext != LIB_EXTENSION {
+            continue;
+        }
+        let libname = if cfg!(windows) {
+            // On windows, the full filename: `name.lib`.
+            let Some(filename) = path.file_name() else {
+                continue;
+            };
+            filename.to_str().expect("absl lib has non-utf8 name")
+        } else {
+            // On unix, drop the lib prefix and the extension: `libname.a` => `name`.
+            let Some(stem) = path.file_stem() else {
+                continue;
+            };
+            let s = stem.to_str().expect("absl lib has non-utf8 name");
+            s.strip_prefix("lib").unwrap_or(s)
+        };
+        if include_lib(libname) {
+            libs.push(OsStr::new(libname).to_owned())
+        }
+    }
+    libs.sort_unstable();
+
+    libs
+}

--- a/build/flags.rs
+++ b/build/flags.rs
@@ -1,0 +1,15 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+pub const CC_FLAGS: &[&str] = &[
+    // TODO(danakj): Crubit has a bunch of warnings in C++ code.
+    "-Wno-everything",
+    // We build with C++20.
+    "-std=c++20",
+    // Expect that LLVM is built without RTTI, and this needs to match. Otherwise we get errors
+    // at link time like "ld.lld: error: undefined symbol: typeinfo for clang::ASTConsumer".
+    //
+    // TODO(danakj): This should probably be configurable.
+    "-fno-rtti",
+];

--- a/build/lib.rs
+++ b/build/lib.rs
@@ -1,0 +1,74 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+mod absl;
+mod clang;
+mod flags;
+mod paths;
+
+use std::path::Path;
+
+/// Build a C++ library of `sources`, with paths specified relative to the source
+/// root.
+///
+/// `path_to_src_root` gives the root of the repo, where paths are specified
+/// relative to.
+///
+/// All C++ libraries can make use of ABSL, LLVM, and Clang, as they are included
+/// in the include path, and are added to the link step.
+pub fn compile_cc_lib<P1: AsRef<Path>, P2: AsRef<Path>>(
+    path_to_src_root: P1,
+    sources: &[P2],
+) -> Result<(), std::io::Error> {
+    let name = std::env::var("CARGO_PKG_NAME").unwrap();
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    // Avoid building object files into the root output directory. If the binary
+    // name matches the directory name of a source file, then we get a
+    // collision. Put it in a subdir of the target's individual output
+    // directory.
+    let obj_dir = Path::new(&out_dir).join("obj");
+
+    paths::print_compiler_deps();
+
+    // ===== Abseil ======
+
+    let absl_include_dir = paths::print_env_to_path("ABSL_INCLUDE_DIR")
+        .expect("ABSL_INCLUDE_DIR must be specified in the environment");
+    let (absl_lib_dir, absl_libs) = absl::collect_absl_libs();
+    paths::print_link_search(absl_lib_dir)?;
+    paths::print_link_libs(&absl_libs)?;
+
+    // ===== libtooling =====
+
+    // TODO: Use llvm-config instead of LIBCLANG_STATIC_PATH?
+    let libclang_static_path = paths::print_env_to_path("LIBCLANG_STATIC_PATH")
+        .expect("LIBCLANG_STATIC_PATH must be specified in the environment");
+    let libclang_include_path = libclang_static_path.parent().unwrap().join("include");
+    let clang_libs = clang::collect_clang_libs(&libclang_static_path);
+    paths::print_link_search(&libclang_static_path)?;
+    paths::print_link_libs(&clang_libs)?;
+
+    // llvm depends on zlib.
+    paths::print_link_libs(&["z"])?;
+
+    // ===== The cc lib ======
+
+    let mut cc_lib = cc::Build::new();
+    cc_lib.out_dir(&obj_dir);
+    for f in flags::CC_FLAGS {
+        cc_lib.flag(f);
+    }
+    cc_lib.include(path_to_src_root.as_ref());
+    for p in sources.into_iter().map(|p| path_to_src_root.as_ref().join(p.as_ref())) {
+        paths::add_source_file(&mut cc_lib, &p)?;
+    }
+    paths::add_include_path(&mut cc_lib, absl_include_dir, true);
+    paths::add_include_path(&mut cc_lib, libclang_include_path, true);
+    cc_lib.compile(&name);
+
+    paths::print_link_search(&obj_dir)?;
+    paths::print_link_libs(&[name])?;
+
+    Ok(())
+}

--- a/build/paths.rs
+++ b/build/paths.rs
@@ -1,0 +1,57 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::ffi::OsStr;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+pub fn print_link_search<T: AsRef<OsStr>>(s: T) -> io::Result<()> {
+    print!("cargo::rustc-link-search=native=");
+    io::stdout().write(s.as_ref().as_encoded_bytes())?;
+    print!("\n");
+    Ok(())
+}
+
+pub fn print_link_libs<T: AsRef<OsStr>>(libs: &[T]) -> io::Result<()> {
+    for lib in libs {
+        print!("cargo::rustc-link-lib=");
+        io::stdout().write(lib.as_ref().as_encoded_bytes())?;
+        print!("\n");
+    }
+    Ok(())
+}
+
+pub fn add_include_path<P: AsRef<Path>>(build: &mut cc::Build, path: P, system: bool) {
+    if system {
+        if cfg!(unix) {
+            build.flag(&format!("-isystem{}", path.as_ref().display()));
+        } else {
+            build.flag(&format!("-I{}", path.as_ref().display()));
+        }
+    } else {
+        build.flag(&format!("-I{}", path.as_ref().display()));
+    }
+}
+
+pub fn print_env_to_path(env_var: &str) -> Option<PathBuf> {
+    println!("cargo:rerun-if-env-changed={}", env_var);
+    Some(Path::new(&std::env::var_os(env_var)?).to_owned())
+}
+
+pub fn add_source_file<P: AsRef<Path>>(build: &mut cc::Build, path: P) -> io::Result<()> {
+    print!("cargo::rerun-if-changed=");
+    io::stdout().write(path.as_ref().as_os_str().as_encoded_bytes())?;
+    print!("\n");
+    build.file(path.as_ref());
+    Ok(())
+}
+
+pub fn print_compiler_deps() {
+    println!("cargo:rerun-if-env-changed=CC");
+    println!("cargo:rerun-if-env-changed=CXX");
+    println!("cargo:rerun-if-env-changed=LD");
+    println!("cargo:rerun-if-env-changed=CFLAGS");
+    println!("cargo:rerun-if-env-changed=CXXFLAGS");
+    println!("cargo:rerun-if-env-changed=LDFLAGS");
+}

--- a/common/cargo/arc_anyhow/Cargo.toml
+++ b/common/cargo/arc_anyhow/Cargo.toml
@@ -1,0 +1,13 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "arc_anyhow"
+edition = "2021"
+
+[lib]
+path = "../../arc_anyhow.rs"
+
+[dependencies]
+anyhow = "1"

--- a/common/cargo/code_gen_utils/Cargo.toml
+++ b/common/cargo/code_gen_utils/Cargo.toml
@@ -1,0 +1,19 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "code_gen_utils"
+edition = "2021"
+
+[lib]
+path = "../../code_gen_utils.rs"
+
+[dependencies]
+once_cell = "1"
+itertools = "0.13"
+proc-macro2 = "1"
+syn = "2"
+quote = "1"
+unicode-ident = "1"
+arc_anyhow = { path = "../../../common/cargo/arc_anyhow" }

--- a/common/cargo/common_sys/Cargo.toml
+++ b/common/cargo/common_sys/Cargo.toml
@@ -1,0 +1,15 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "common_sys"
+edition = "2021"
+
+build = "build.rs"
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+crubit_build = { path = "../../../build" }

--- a/common/cargo/common_sys/build.rs
+++ b/common/cargo/common_sys/build.rs
@@ -1,0 +1,15 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+const PATH_TO_SRC_ROOT: &str = "../../..";
+
+fn main() {
+    crubit_build::compile_cc_lib(PATH_TO_SRC_ROOT, SOURCES).unwrap();
+}
+
+// TODO(danakj): Pull this out of the BUILD somehow?
+//
+// TODO(danakj): Split these up into separate Cargo targets so incremental
+// builds of C++ changes are fast?
+const SOURCES: &[&str] = &["common/ffi_types.cc", "common/file_io.cc"];

--- a/common/cargo/common_sys/lib.rs
+++ b/common/cargo/common_sys/lib.rs
@@ -1,0 +1,3 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/common/cargo/ffi_types/Cargo.toml
+++ b/common/cargo/ffi_types/Cargo.toml
@@ -1,0 +1,14 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "ffi_types"
+edition = "2021"
+
+[lib]
+path = "../../ffi_types.rs"
+
+[dependencies]
+serde = { version = "1", features = [ "derive", "rc" ] }
+arc_anyhow = { path = "../../../common/cargo/arc_anyhow" }

--- a/common/cargo/item_exists/Cargo.toml
+++ b/common/cargo/item_exists/Cargo.toml
@@ -1,0 +1,10 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "item_exists"
+edition = "2021"
+
+[lib]
+path = "../../item_exists.rs"

--- a/common/cargo/memoized/Cargo.toml
+++ b/common/cargo/memoized/Cargo.toml
@@ -1,0 +1,10 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "memoized"
+edition = "2021"
+
+[lib]
+path = "../../memoized.rs"

--- a/common/cargo/token_stream_matchers/Cargo.toml
+++ b/common/cargo/token_stream_matchers/Cargo.toml
@@ -1,0 +1,15 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "token_stream_matchers"
+edition = "2021"
+
+[lib]
+path = "../../token_stream_matchers.rs"
+
+[dependencies]
+anyhow = "1"
+proc-macro2 = "1"
+token_stream_printer = { path = "../../../common/cargo/token_stream_printer" }

--- a/common/cargo/token_stream_printer/Cargo.toml
+++ b/common/cargo/token_stream_printer/Cargo.toml
@@ -1,0 +1,14 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "token_stream_printer"
+edition = "2021"
+
+[lib]
+path = "../../token_stream_printer.rs"
+
+[dependencies]
+anyhow = "1"
+proc-macro2 = "1"

--- a/lifetime_analysis/cargo/lifetime_analysis_sys/Cargo.toml
+++ b/lifetime_analysis/cargo/lifetime_analysis_sys/Cargo.toml
@@ -1,0 +1,15 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "lifetime_analysis_sys"
+edition = "2021"
+
+build = "build.rs"
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+crubit_build = { path = "../../../build" }

--- a/lifetime_analysis/cargo/lifetime_analysis_sys/build.rs
+++ b/lifetime_analysis/cargo/lifetime_analysis_sys/build.rs
@@ -1,0 +1,27 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+const PATH_TO_SRC_ROOT: &str = "../../..";
+
+fn main() {
+    crubit_build::compile_cc_lib(PATH_TO_SRC_ROOT, SOURCES).unwrap();
+}
+
+// TODO(danakj): Pull this out of the BUILD somehow?
+//
+// TODO(danakj): Split these up into separate Cargo targets so incremental
+// builds of C++ changes are fast?
+const SOURCES: &[&str] = &[
+    "lifetime_analysis/analyze.cc",
+    "lifetime_analysis/builtin_lifetimes.cc",
+    "lifetime_analysis/lifetime_analysis.cc",
+    "lifetime_analysis/lifetime_constraints.cc",
+    "lifetime_analysis/lifetime_lattice.cc",
+    "lifetime_analysis/object.cc",
+    "lifetime_analysis/object_repository.cc",
+    "lifetime_analysis/object_set.cc",
+    "lifetime_analysis/pointer_compatibility.cc",
+    "lifetime_analysis/points_to_map.cc",
+    "lifetime_analysis/template_placeholder_support.cc",
+];

--- a/lifetime_analysis/cargo/lifetime_analysis_sys/lib.rs
+++ b/lifetime_analysis/cargo/lifetime_analysis_sys/lib.rs
@@ -1,0 +1,3 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/lifetime_annotations/cargo/lifetime_annotations_sys/Cargo.toml
+++ b/lifetime_annotations/cargo/lifetime_annotations_sys/Cargo.toml
@@ -1,0 +1,15 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "lifetime_annotations_sys"
+edition = "2021"
+
+build = "build.rs"
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+crubit_build = { path = "../../../build" }

--- a/lifetime_annotations/cargo/lifetime_annotations_sys/build.rs
+++ b/lifetime_annotations/cargo/lifetime_annotations_sys/build.rs
@@ -1,0 +1,23 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+const PATH_TO_SRC_ROOT: &str = "../../..";
+
+fn main() {
+    crubit_build::compile_cc_lib(PATH_TO_SRC_ROOT, SOURCES).unwrap();
+}
+
+// TODO(danakj): Pull this out of the BUILD somehow?
+//
+// TODO(danakj): Split these up into separate Cargo targets so incremental
+// builds of C++ changes are fast?
+const SOURCES: &[&str] = &[
+    "lifetime_annotations/function_lifetimes.cc",
+    "lifetime_annotations/lifetime_annotations.cc",
+    "lifetime_annotations/lifetime.cc",
+    "lifetime_annotations/lifetime_substitutions.cc",
+    "lifetime_annotations/lifetime_symbol_table.cc",
+    "lifetime_annotations/pointee_type.cc",
+    "lifetime_annotations/type_lifetimes.cc",
+];

--- a/lifetime_annotations/cargo/lifetime_annotations_sys/lib.rs
+++ b/lifetime_annotations/cargo/lifetime_annotations_sys/lib.rs
@@ -1,0 +1,3 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/rs_bindings_from_cc/BUILD
+++ b/rs_bindings_from_cc/BUILD
@@ -12,6 +12,7 @@ load(
     "//common:crubit_wrapper_macros_oss.bzl",
     "crubit_cc_binary",
     "crubit_cc_test",
+    "crubit_rust_binary",
     "crubit_rust_test",
 )
 load(
@@ -41,7 +42,7 @@ with_cc_toolchain_flags(
 
 rust_bindings_from_cc_binary(
     name = "rs_bindings_from_cc",
-    binary = ":rs_bindings_from_cc_impl",
+    binary = ":rs_bindings_from_cc_main",
     visibility = ["//:__subpackages__"],
 )
 
@@ -61,10 +62,26 @@ deps_for_bindings(
     visibility = ["//:__subpackages__"],
 )
 
-crubit_cc_binary(
-    name = "rs_bindings_from_cc_impl",
+crubit_rust_binary(
+    name = "rs_bindings_from_cc_main",
     srcs = ["rs_bindings_from_cc.cc"],
     visibility = ["//visibility:public"],
+    deps = [
+        ":rs_bindings_from_cc_sys",
+    ],
+)
+
+rust_library(
+    name = "rs_bindings_from_cc_sys",
+    srcs = ["rs_bindings_from_cc_sys.rs"],
+    deps = [
+        ":rs_bindings_from_cc_impl",
+    ],
+)
+
+cc_library(
+    name = "rs_bindings_from_cc_impl",
+    srcs = ["rs_bindings_from_cc.cc"],
     deps = [
         ":cc_ir",
         ":cmdline",

--- a/rs_bindings_from_cc/cargo/collect_instantiations/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/collect_instantiations/Cargo.toml
@@ -1,0 +1,17 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "collect_instantiations"
+edition = "2021"
+
+[lib]
+path = "../../collect_instantiations.rs"
+
+[dependencies]
+proc-macro2 = "1"
+serde_json = "1"
+syn = "2"
+arc_anyhow = { path = "../../../common/cargo/arc_anyhow" }
+ffi_types = { path = "../../../common/cargo/ffi_types" }

--- a/rs_bindings_from_cc/cargo/error_report/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/error_report/Cargo.toml
@@ -1,0 +1,16 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "error_report"
+edition = "2021"
+
+[lib]
+path = "../../error_report.rs"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = [ "derive", "rc" ] }
+serde_json = "1"
+arc_anyhow = { path = "../../../common/cargo/arc_anyhow" }

--- a/rs_bindings_from_cc/cargo/generate_bindings/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/generate_bindings/Cargo.toml
@@ -1,0 +1,26 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "generate_bindings"
+edition = "2021"
+
+[lib]
+path = "../../generate_bindings/lib.rs"
+
+[dependencies]
+anyhow = "1"
+itertools = "0.13"
+flagset = "0.4"
+once_cell = "1"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = [ "extra-traits" ] }
+arc_anyhow = { path = "../../../common/cargo/arc_anyhow" }
+code_gen_utils = { path = "../../../common/cargo/code_gen_utils" }
+error_report = { path = "../error_report" }
+ffi_types = { path = "../../../common/cargo/ffi_types" }
+ir = { path = "../ir" }
+memoized = { path = "../../../common/cargo/memoized" }
+token_stream_printer = { path = "../../../common/cargo/token_stream_printer" }

--- a/rs_bindings_from_cc/cargo/ir/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/ir/Cargo.toml
@@ -1,0 +1,20 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "ir"
+edition = "2021"
+
+[lib]
+path = "../../ir.rs"
+
+[dependencies]
+flagset = "0.4"
+once_cell = "1"
+proc-macro2 = "1"
+quote = "1"
+serde = { version = "1", features = ["derive", "rc"] }
+serde_json = "1"
+arc_anyhow = { path = "../../../common/cargo/arc_anyhow" }
+code_gen_utils = { path = "../../../common/cargo/code_gen_utils" }

--- a/rs_bindings_from_cc/cargo/ir_matchers/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/ir_matchers/Cargo.toml
@@ -1,0 +1,19 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "ir_matchers"
+edition = "2021"
+
+[lib]
+path = "../../ir_matchers.rs"
+
+[dependencies]
+anyhow = "1"
+itertools = "0.13"
+proc-macro2 = "1"
+quote = "1"
+ir = { path = "../../../rs_bindings_from_cc/cargo/ir" }
+token_stream_printer = { path = "../../../common/cargo/token_stream_printer" }
+token_stream_matchers = { path = "../../../common/cargo/token_stream_matchers" }

--- a/rs_bindings_from_cc/cargo/rs_bindings_from_cc/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/rs_bindings_from_cc/Cargo.toml
@@ -1,0 +1,14 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "rs_bindings_from_cc"
+edition = "2021"
+
+[[bin]]
+name = "rs_bindings_from_cc"
+path = "../../rs_bindings_from_cc.rs"
+
+[dependencies]
+rs_bindings_from_cc_sys = { path = "../rs_bindings_from_cc_sys" }

--- a/rs_bindings_from_cc/cargo/rs_bindings_from_cc_sys/Cargo.toml
+++ b/rs_bindings_from_cc/cargo/rs_bindings_from_cc_sys/Cargo.toml
@@ -1,0 +1,29 @@
+# Part of the Crubit project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[package]
+name = "rs_bindings_from_cc_sys"
+edition = "2021"
+
+build = "build.rs"
+
+[lib]
+path = "../../rs_bindings_from_cc_sys.rs"
+
+[dependencies]
+# NOTE: These dependencies are used only from the C++ lib. They must each appear
+# as `extern crate X` in order to prevent them from being dropped at link time.
+collect_instantiations = { path = "../collect_instantiations" }
+common_sys = { path = "../../../common/cargo/common_sys" }
+generate_bindings = { path = "../generate_bindings" }
+lifetime_analysis_sys = { path = "../../../lifetime_analysis/cargo/lifetime_analysis_sys" }
+lifetime_annotations_sys = { path = "../../../lifetime_annotations/cargo/lifetime_annotations_sys" }
+
+[build-dependencies]
+crubit_build = { path = "../../../build" }
+
+[features]
+default = [ "crubit_cargo_build" ]
+crubit_cargo_build = []
+

--- a/rs_bindings_from_cc/cargo/rs_bindings_from_cc_sys/build.rs
+++ b/rs_bindings_from_cc/cargo/rs_bindings_from_cc_sys/build.rs
@@ -1,0 +1,41 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+const PATH_TO_SRC_ROOT: &str = "../../..";
+
+fn main() {
+    crubit_build::compile_cc_lib(PATH_TO_SRC_ROOT, SOURCES).unwrap();
+}
+
+// TODO(danakj): Pull this out of the BUILD somehow?
+//
+// TODO(danakj): Split these up into separate Cargo targets so incremental
+// builds of C++ changes are fast?
+const SOURCES: &[&str] = &[
+    "rs_bindings_from_cc/ast_consumer.cc",
+    "rs_bindings_from_cc/ast_convert.cc",
+    "rs_bindings_from_cc/ast_util.cc",
+    "rs_bindings_from_cc/cmdline.cc",
+    "rs_bindings_from_cc/collect_instantiations.cc",
+    "rs_bindings_from_cc/collect_namespaces.cc",
+    "rs_bindings_from_cc/frontend_action.cc",
+    "rs_bindings_from_cc/generate_bindings_and_metadata.cc",
+    "rs_bindings_from_cc/importer.cc",
+    "rs_bindings_from_cc/ir.cc",
+    "rs_bindings_from_cc/ir_from_cc.cc",
+    "rs_bindings_from_cc/json_from_cc.cc",
+    "rs_bindings_from_cc/recording_diagnostic_consumer.cc",
+    "rs_bindings_from_cc/rs_bindings_from_cc.cc",
+    "rs_bindings_from_cc/src_code_gen.cc",
+    "rs_bindings_from_cc/type_map.cc",
+    "rs_bindings_from_cc/importers/class_template.cc",
+    "rs_bindings_from_cc/importers/cxx_record.cc",
+    "rs_bindings_from_cc/importers/enum.cc",
+    "rs_bindings_from_cc/importers/friend.cc",
+    "rs_bindings_from_cc/importers/function.cc",
+    "rs_bindings_from_cc/importers/function_template.cc",
+    "rs_bindings_from_cc/importers/namespace.cc",
+    "rs_bindings_from_cc/importers/type_alias.cc",
+    "rs_bindings_from_cc/importers/type_map_override.cc",
+];

--- a/rs_bindings_from_cc/cargo/rs_bindings_from_cc_sys/lib.rs
+++ b/rs_bindings_from_cc/cargo/rs_bindings_from_cc_sys/lib.rs
@@ -1,0 +1,3 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/rs_bindings_from_cc/rs_bindings_from_cc.cc
+++ b/rs_bindings_from_cc/rs_bindings_from_cc.cc
@@ -95,7 +95,7 @@ absl::Status Main(absl::Span<char* const> positional_args) {
 
 }  // namespace crubit
 
-int main(int argc, char* argv[]) {
+extern "C" int crubit_rs_bindings_from_cc_main(int argc, char* argv[]) {
   crubit::ExpandParamfiles(argc, argv);
   crubit::PreprocessTargetArgs(argc, argv);
   auto args = absl::ParseCommandLine(argc, argv);

--- a/rs_bindings_from_cc/rs_bindings_from_cc.rs
+++ b/rs_bindings_from_cc/rs_bindings_from_cc.rs
@@ -1,0 +1,28 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::ffi::{c_char, CString};
+
+fn main() -> Result<(), i32> {
+    let mut args: Vec<Vec<u8>> = std::env::args_os()
+        .map(|s| {
+            CString::new(s.into_encoded_bytes())
+                .unwrap()
+                .into_bytes_with_nul()
+        })
+        .collect();
+    // Pointers to each Vec storage in `args`, which must outlive this.
+    let mut ptrs: Vec<*mut c_char> = args
+        .iter_mut()
+        .map(|s| s.as_mut_ptr() as *mut c_char)
+        .collect();
+    let argc: i32 = ptrs.len().try_into().unwrap();
+    let argv: *mut *mut c_char = ptrs.as_mut_ptr();
+    let r = unsafe { rs_bindings_from_cc_sys::crubit_rs_bindings_from_cc_main(argc, argv) };
+    if r == 0 {
+        Ok(())
+    } else {
+        Err(r)
+    }
+}

--- a/rs_bindings_from_cc/rs_bindings_from_cc_sys.rs
+++ b/rs_bindings_from_cc/rs_bindings_from_cc_sys.rs
@@ -1,0 +1,25 @@
+// Part of the Crubit project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::ffi::{c_char, c_int};
+
+extern "C" {
+    pub fn crubit_rs_bindings_from_cc_main(argc: c_int, argv: *mut *mut c_char) -> std::ffi::c_int;
+}
+
+// Dependencies from C++ code, avoid cargo/rustc pruning them.
+//
+// TODO(danakj): How do we keep cargo/rustc from pruning these dependencies from
+// the linker line without adding these statements? Bazel does not have this
+// issue.
+#[cfg(feature = "crubit_cargo_build")]
+extern crate collect_instantiations;
+#[cfg(feature = "crubit_cargo_build")]
+extern crate common_sys;
+#[cfg(feature = "crubit_cargo_build")]
+extern crate generate_bindings;
+#[cfg(feature = "crubit_cargo_build")]
+extern crate lifetime_analysis_sys;
+#[cfg(feature = "crubit_cargo_build")]
+extern crate lifetime_annotations_sys;


### PR DESCRIPTION
The target's C++ code depends on:
* Abseil
* LLVM
* Clang
* Zlib

And these libraries must be built and provided separately. They are specified in the environment as:
* ABSL_INCLUDE_DIR
* ABSL_LIB_DIR
* LIBCLANG_STATIC_PATH

libz is looked for in the system library directories, which may be a problem. The same zlib should be used for both LLVM and for Crubit, and this isn't being enforced if we don't control where it is linked from. OTOH it's hard to control if the library is also present in the system library paths.

In order to avoid link ordering issues, the linker should be specified as `clang` with a link argument of `-Clink-arg=-fuse-ld=lld`.

On linux, the C++ std library needs to be explicitly linked by adding it to the link arguments, such as `-Clink-arg=-lstdc++`.

Chromium builds LLVM without RTTI, so it must also be disabled in Crubit, so flags.rs currently assumes this is desired and unilaterally passes -fno-rtti.

Crubit has a number of warnings in the C++ files, so to keep any errors quieter for diagnosis, we pass `-Wno-everything` in the Cargo build. It would be better to clean up those errors and turn them back on so that changing the C++ code while using the Cargo build generates that useful feedback to the developer.

The C++ targets are grouped together into a few larger libraries, which makes incremental C++ builds slower. It would be ideal to split them into separate Cargo targets for each C++ file, as is done for the Blaze build, but this is left for another step.

This script can build and run rs_bindings_from_cc via cargo, against the Chromium Rust toolchain build artifacts (after running build_rust.py in Chromium).

```
CHROMIUM=$HOME/s/c/src
LLVM_INSTALL=$CHROMIUM/third_party/rust-toolchain-intermediate/llvm-host-install
ZLIB_DIR=$CHROMIUM/third_party/rust-toolchain-intermediate/zlib
SYSROOT=$CHROMIUM/third_party/llvm-build-tools/debian_bullseye_amd64_sysroot

export LLVM_CONFIG_PATH=$LLVM_INSTALL/bin/llvm-config
export LIBCLANG_STATIC_PATH=$LLVM_INSTALL/lib

export CC=$LLVM_INSTALL/bin/clang
export CXX=$LLVM_INSTALL/bin/clang++
export LD=$LLVM_INSTALL/bin/lld

export RUSTFLAGS=""
export LDFLAGS=""

export RUSTFLAGS="$RUSTFLAGS -Clinker=$LLVM_INSTALL/bin/clang"

export LDFLAGS="$LDFLAGS -fuse-ld=lld"
export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-fuse-ld=lld"

export LDFLAGS="$LDFLAGS -lstdc++"
export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-lstdc++"

SYSROOT_FLAG=--sysroot=$SYSROOT
export CFLAGS="$CFLAGS $SYSROOT_FLAG"
export CXXFLAGS="$CXXFLAGS $SYSROOT_FLAG"
export LDFLAGS="$LDFLAGS $SYSROOT_FLAG"
export RUSTFLAGS="$RUSTFLAGS -Clink-arg=$SYSROOT_FLAG"

ABSL_GIT=https://github.com/abseil/abseil-cpp
ABSL_HASH=eb852207758a7739653
ABSL_INSTALL_DIR=$PWD/absl/install
ABSL_BUILD_DIR=absl

if ! test -d $ABSL_BUILD_DIR; then
  D="$PWD"
  git clone $ABSL_GIT $ABSL_BUILD_DIR
  cd $ABSL_BUILD_DIR
  git checkout $ABSL_HASH
  cmake -B out \
    -DCMAKE_CXX_STANDARD=20 \
    -DCMAKE_INSTALL_PREFIX=$ABSL_INSTALL_DIR \
    -DABSL_BUILD_TESTING=OFF \
    -DABSL_USE_GOOGLETEST_HEAD=OFF
  cmake --build out --target all
  cmake --install out
  cd $D
fi

export ABSL_INCLUDE_DIR=$ABSL_INSTALL_DIR/include
export ABSL_LIB_DIR=$ABSL_INSTALL_DIR/lib

cargo run --bin rs_bindings_from_cc -- $*
```