### PR TITLE
Use a rust-toolchain.toml file.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustc-dev", "llvm-tools"]


### PR DESCRIPTION
This gets us a much better default build experience: `cargo build --bin cc_bindings_from_rs` will automatically use nightly and install the required components, instead of requiring this "oh yeah, what did I need to install again?" setup process.

And hey, what do you know, build is still green!

Should probably use a specific nightly, but I'm not sure how that works yet. (Since we probably want to test against multiple nightlies, I'm not sure if it's wise to hardcode a specific one here.)