### PR TITLE
Create a Rust CI workflow for just building cc_bindings_from_rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose --bin cc_bindings_from_rs
+    # - name: Run tests
+    #   run: cargo test --verbose


### PR DESCRIPTION
cargo test doesn't work yet (fails to build!), and I'd rather start iterating on the workflow with a subset that does work. So, the idea is, create the workflow, and then enable it and make sure to surface its results internally as well, and then fix coverage and make it run tests and so on.