### PR TITLE
Fix nightly break in cc_bindings_from_rs

### DIFF
--- a/cargo/cc_bindings_from_rs/generate_bindings/query_compiler/Cargo.toml
+++ b/cargo/cc_bindings_from_rs/generate_bindings/query_compiler/Cargo.toml
@@ -20,3 +20,4 @@ doctest = false
 [dependencies]
 arc_anyhow = { path = "../../../../cargo/common/arc_anyhow"}
 error_report = { path = "../../../../cargo/common/error_report"}
+rustversion.workspace = true

--- a/cc_bindings_from_rs/generate_bindings/BUILD
+++ b/cc_bindings_from_rs/generate_bindings/BUILD
@@ -136,6 +136,9 @@ rust_library(
     srcs = [
         "query_compiler.rs",
     ],
+    proc_macro_deps = [
+        "//third_party/rust/rustversion/v1:rustversion",
+    ],
     # LINT.IfChange
     rustc_flags = ["-Zallow-features=rustc_private,rustc_attr"],
     # LINT.ThenChange(//docs/overview/unstable_features.md)


### PR DESCRIPTION
Update our code to include lightest API changes in nightly rust (guarded by the version they were introduced 2026-01-29).