### PR TITLE
ci: declare GITHUB_TOKEN permissions on cargo and nightly workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,6 +5,8 @@ name: Crubit Nightly Test Matrix
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   use-test-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 # LINT.IfChange
 jobs:
   test:


### PR DESCRIPTION
Two workflows currently leave `GITHUB_TOKEN` scope implicit:

- **`nightly.yaml`** — stub that just echoes a redirect message and `exit 1`s. No checkout, no install, no API. `permissions: {}` (deny all) is correct here.
- **`rust.yml`** — two jobs (`test`, `test_cmake`) running `cargo test` / `cargo build` / `cmake build && ctest`. Pure CI; `contents: read` at the workflow level covers the `actions/checkout` step and the cache restore. Nothing here pushes commits or calls write APIs.

`mdbook.yaml` already declares explicit permissions for the GH Pages deployment; this just brings the other two in line.