### PR TITLE
Fix `ffi_11` LLP64/Windows support

### DIFF
--- a/support/ffi_11/src/newtype.rs
+++ b/support/ffi_11/src/newtype.rs
@@ -265,15 +265,16 @@ macro_rules! new_integer {
       $crate::newtype::wrapped_to_primitive!{
         impl From<$IntegerType> for i32;
         impl From<$IntegerType> for i64;
-        impl From<$IntegerType> for u64;
         impl From<$IntegerType> for i128;
-        impl From<$IntegerType> for u128;
         impl From<$IntegerType> for ::core::sync::atomic::AtomicI32;
         impl From<$IntegerType> for f64;
       }
       $crate::newtype::primitive_to_wrapped!{
+        impl From<u8> for $IntegerType;
         impl From<i8> for $IntegerType;
+        impl From<u16> for $IntegerType;
         impl From<i16> for $IntegerType;
+        impl From<i32> for $IntegerType;
       }
     };
     (@__from, $IntegerType:ident, u32) => {
@@ -285,6 +286,11 @@ macro_rules! new_integer {
         impl From<$IntegerType> for u128;
         impl From<$IntegerType> for ::core::sync::atomic::AtomicU32;
         impl From<$IntegerType> for f64;
+      }
+      $crate::newtype::primitive_to_wrapped!{
+        impl From<u8> for $IntegerType;
+        impl From<u16> for $IntegerType;
+        impl From<u32> for $IntegerType;
       }
     };
     (@__from, $IntegerType:ident, i64) => {


### PR DESCRIPTION
The newtype macros for `i32` and `u32` had some incorrect and missing conversions.

This change makes the `ffi_11` crate build successfully for me on Windows with:

- Today's Rust `nightly-x86_64-pc-windows-msvc` toolchain, version `1.97.0-nightly (e50aa6fba 2026-05-19)`
- MSVC v143 - VS 2022 C++ x64/x86 build tools