### PR TITLE
Fix macOS CMake build: emit INTERFACE libraries for header-only support targets

### DIFF
--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -4,43 +4,31 @@
 
 # Automatically @generated CMakeLists.txt.
 
-add_library(crubit_support_annotations STATIC
-"annotations.h"
-)
-set_target_properties(crubit_support_annotations PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_annotations INTERFACE)
 
-target_include_directories(crubit_support_annotations PUBLIC
+target_include_directories(crubit_support_annotations INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 
-target_link_libraries(crubit_support_annotations PUBLIC
+target_link_libraries(crubit_support_annotations INTERFACE
 crubit_support_annotations_internal
 )
 
-add_library(crubit_support_annotations_internal STATIC
-"annotations_internal.h"
-)
-set_target_properties(crubit_support_annotations_internal PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_annotations_internal INTERFACE)
 
-target_include_directories(crubit_support_annotations_internal PUBLIC
+target_include_directories(crubit_support_annotations_internal INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 
-add_library(crubit_support_bridge_cpp STATIC
-"bridge.h"
-)
-set_target_properties(crubit_support_bridge_cpp PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_bridge_cpp INTERFACE)
 
-target_include_directories(crubit_support_bridge_cpp PUBLIC
+target_include_directories(crubit_support_bridge_cpp INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 
-add_library(crubit_support_lifetime_annotations STATIC
-"lifetime_annotations.h"
-)
-set_target_properties(crubit_support_lifetime_annotations PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_lifetime_annotations INTERFACE)
 
-target_include_directories(crubit_support_lifetime_annotations PUBLIC
+target_include_directories(crubit_support_lifetime_annotations INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 

--- a/support/rs_std/CMakeLists.txt
+++ b/support/rs_std/CMakeLists.txt
@@ -20,137 +20,104 @@ crubit_support_annotations
 crubit_support_internal_bindings_support
 )
 
-add_library(crubit_support_rs_std_dyn_callable STATIC
-"dyn_callable.h"
-)
-set_target_properties(crubit_support_rs_std_dyn_callable PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_dyn_callable INTERFACE)
 
-target_include_directories(crubit_support_rs_std_dyn_callable PUBLIC
+target_include_directories(crubit_support_rs_std_dyn_callable INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_dyn_callable PUBLIC
+target_link_libraries(crubit_support_rs_std_dyn_callable INTERFACE
 absl::core_headers
 absl::nullability
 absl::any_invocable
 crubit_support_bridge_cpp
 )
 
-add_library(crubit_support_rs_std_dyn_erased_future_cc STATIC
-"dyn_erased_future.h"
-)
-set_target_properties(crubit_support_rs_std_dyn_erased_future_cc PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_dyn_erased_future_cc INTERFACE)
 
-target_include_directories(crubit_support_rs_std_dyn_erased_future_cc PUBLIC
+target_include_directories(crubit_support_rs_std_dyn_erased_future_cc INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_dyn_erased_future_cc PUBLIC
+target_link_libraries(crubit_support_rs_std_dyn_erased_future_cc INTERFACE
 crubit_support_rs_std_waker
 )
 
-add_library(crubit_support_rs_std_iterator_adapter STATIC
-"iterator_adapter.h"
-)
-set_target_properties(crubit_support_rs_std_iterator_adapter PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_iterator_adapter INTERFACE)
 
-target_include_directories(crubit_support_rs_std_iterator_adapter PUBLIC
+target_include_directories(crubit_support_rs_std_iterator_adapter INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_iterator_adapter PUBLIC
+target_link_libraries(crubit_support_rs_std_iterator_adapter INTERFACE
 crubit_support_rs_std_traits
 )
 
-add_library(crubit_support_rs_std_lossy_formatter_for_bindings STATIC
-"lossy_formatter_for_bindings.h"
-)
-set_target_properties(crubit_support_rs_std_lossy_formatter_for_bindings PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_lossy_formatter_for_bindings INTERFACE)
 
-target_include_directories(crubit_support_rs_std_lossy_formatter_for_bindings PUBLIC
+target_include_directories(crubit_support_rs_std_lossy_formatter_for_bindings INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-add_library(crubit_support_rs_std_option STATIC
-"option.h"
-)
-set_target_properties(crubit_support_rs_std_option PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_option INTERFACE)
 
-target_include_directories(crubit_support_rs_std_option PUBLIC
+target_include_directories(crubit_support_rs_std_option INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_option PUBLIC
+target_link_libraries(crubit_support_rs_std_option INTERFACE
 crubit_support_internal_bindings_support
 )
 
-add_library(crubit_support_rs_std_result STATIC
-"result.h"
-)
-set_target_properties(crubit_support_rs_std_result PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_result INTERFACE)
 
-target_include_directories(crubit_support_rs_std_result PUBLIC
+target_include_directories(crubit_support_rs_std_result INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_result PUBLIC
+target_link_libraries(crubit_support_rs_std_result INTERFACE
 crubit_support_internal_bindings_support
 )
 
-add_library(crubit_support_rs_std_slice_ref STATIC
-"slice_ref.h"
-)
-set_target_properties(crubit_support_rs_std_slice_ref PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_slice_ref INTERFACE)
 
-target_include_directories(crubit_support_rs_std_slice_ref PUBLIC
+target_include_directories(crubit_support_rs_std_slice_ref INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_slice_ref PUBLIC
+target_link_libraries(crubit_support_rs_std_slice_ref INTERFACE
 crubit_support_annotations
 crubit_support_internal_bindings_support
 )
 
-add_library(crubit_support_rs_std_str_ref STATIC
-"str_ref.h"
-)
-set_target_properties(crubit_support_rs_std_str_ref PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_str_ref INTERFACE)
 
-target_include_directories(crubit_support_rs_std_str_ref PUBLIC
+target_include_directories(crubit_support_rs_std_str_ref INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-target_link_libraries(crubit_support_rs_std_str_ref PUBLIC
+target_link_libraries(crubit_support_rs_std_str_ref INTERFACE
 crubit_support_rs_std_slice_ref
 crubit_support_annotations_internal
 crubit_support_internal_bindings_support
 crubit_support_rs_std_internal_is_utf8
 )
 
-add_library(crubit_support_rs_std_traits STATIC
-"traits.h"
-)
-set_target_properties(crubit_support_rs_std_traits PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_traits INTERFACE)
 
-target_include_directories(crubit_support_rs_std_traits PUBLIC
+target_include_directories(crubit_support_rs_std_traits INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-add_library(crubit_support_rs_std_tuple STATIC
-"tuple.h"
-)
-set_target_properties(crubit_support_rs_std_tuple PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_tuple INTERFACE)
 
-target_include_directories(crubit_support_rs_std_tuple PUBLIC
+target_include_directories(crubit_support_rs_std_tuple INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 
-add_library(crubit_support_rs_std_vec STATIC
-"vec.h"
-)
-set_target_properties(crubit_support_rs_std_vec PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_vec INTERFACE)
 
-target_include_directories(crubit_support_rs_std_vec PUBLIC
+target_include_directories(crubit_support_rs_std_vec INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../.."
 )
 

--- a/support/rs_std/internal/CMakeLists.txt
+++ b/support/rs_std/internal/CMakeLists.txt
@@ -4,12 +4,9 @@
 
 # Automatically @generated CMakeLists.txt.
 
-add_library(crubit_support_rs_std_internal_is_utf8 STATIC
-"is_utf8.h"
-)
-set_target_properties(crubit_support_rs_std_internal_is_utf8 PROPERTIES LINKER_LANGUAGE CXX)
+add_library(crubit_support_rs_std_internal_is_utf8 INTERFACE)
 
-target_include_directories(crubit_support_rs_std_internal_is_utf8 PUBLIC
+target_include_directories(crubit_support_rs_std_internal_is_utf8 INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/../../.."
 )
 


### PR DESCRIPTION
Hello!  I'm new to crubit!  

I suspect, since these CMake files are generated this is not the PR that want to go in but perhaps a generation script needs changing instead?  Would it be possible to amend this so I can build on Mac? 

## Problem

The CMake build fails on macOS for the header-only support libraries. They're declared as STATIC archives, but they have no .cc sources only headers. Apple's ar refuses to create an empty archive:

ar: no archive members specified

## Fix Proposal

Someone else would need to update the script that generates these CMake files.

If header only targets use CMake INTERFACE instead of STATIC 
https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries
Then the archive step is skipped but includes and link dependencies are still propagated.  