### PR TITLE
docs: retire Bazel-provided LLVM build instructions

### DIFF
--- a/docs/cpp/building.md
+++ b/docs/cpp/building.md
@@ -100,12 +100,9 @@ cargo build --bin rs_bindings_from_cc
 
 ## Bazel
 
-```sh
-apt install clang lld bazel
-git clone git@github.com:google/crubit.git
-cd crubit
-bazel build --linkopt=-fuse-ld=/usr/bin/ld.lld //rs_bindings_from_cc:rs_bindings_from_cc_impl
-```
+Building with the Bazel-provided LLVM installation without `LLVM_INSTALL_PATH` is not supported. The instructions that used `bazel/llvm.bzl` to download LLVM via the `llvm-raw` repository are API incompatible and the LLVM Bazel build is not actively maintained, as described in https://github.com/google/crubit/issues/3. That option has been retired to simplify the user setup and contract the support surface.
+
+Use a prebuilt LLVM tree via `LLVM_INSTALL_PATH` as the supported Bazel workflow:
 
 ### Using a prebuilt LLVM tree
 


### PR DESCRIPTION
Fixes #3

What was wrong:
The Bazel section in docs/cpp/building.md documented a build without LLVM_INSTALL_PATH that used bazel/llvm.bzl to download LLVM via the llvm-raw repository. As described in #3, the commit at bazel/llvm.bzl:56 is API incompatible with lifetime_annotations/type_lifetimes.cc and updating the commit still fails with missing bazel_skylib expand_template.bzl. The LLVM Bazel build is not actively maintained, and keeping this option increases user confusion and support surface.

What changed:
In docs/cpp/building.md:101, retired the standalone bazel build command without LLVM_INSTALL_PATH. Added a note that building with the Bazel-provided LLVM installation without LLVM_INSTALL_PATH is not supported and was retired per #3, and that the supported Bazel workflow is the prebuilt LLVM tree via LLVM_INSTALL_PATH at docs/cpp/building.md:110. No code or reversible Copybara transforms were touched.

Testing:
- No code change, docs only.
- Verified via cargo build --bin cc_bindings_from_rs guidance in CONTRIBUTING.md that the cargo path is the only testable direction on GitHub and is unchanged.
- The change does not touch reversible transforms like @crate_index//:syn formatting.
