### PR TITLE
Enabling GCC - The trivial_abi rabbit hole

### DIFF
--- a/support/bridge.h
+++ b/support/bridge.h
@@ -6,7 +6,7 @@
 #define THIRD_PARTY_CRUBIT_SUPPORT_BRIDGE_H_
 
 // Allow others to check #ifdef CRUBIT_BRIDGE_ENABLED
-#if !defined(SWIG) && defined(__clang__) && __cplusplus >= 202002L
+#if !defined(SWIG) && (defined(__clang__) || defined(__GNUC__)) && __cplusplus >= 202002L
 #define CRUBIT_BRIDGE_ENABLED
 
 #include <concepts>


### PR DESCRIPTION
Ref https://github.com/KHicketts/crubit/issues/1

## The Problem

Crubit ```support/bridge.h``` is some magicks to pass complex types (e.g. ```Option<T>```) as byte buffers in an ABI friendly way between languages.  At the moment, it is only enabled for clang. 

## TLDR: Question for Taylor C & Ethan S

This could be one obvious one liner change but is this safe?  
- Can you confirm that ```[[clang::trivial_abi]]``` types are not passed by value over the ```extern "C"``` boundary?  
- Is there a use case that matters if gcc ignores ```[[clang::trivial_abi]]``` - if per the [unpin documentation](https://github.com/google/crubit/blob/b4f9f89136dff9cef7dfa5fb09f483e553a57072/docs/design/unpin.md) it's only used to tell the rust side if it can move a cpp type that's been passed in or if it must be behind a Pin.
- I'm really only considering linux & macOs.  Perhaps narrowing the enablement to ```... (defined(__clang__) || (defined(__GNUC__) && (defined(__linux__) || defined(__APPLE__))))...``` is a more sensible first step?

## A Rabbit Hole I Entered - Trivial ABI

I'm looking at  base:  https://github.com/google/crubit/blob/b4f9f89136dff9cef7dfa5fb09f483e553a57072/
e.g. 
https://github.com/google/crubit/blob/b4f9f89136dff9cef7dfa5fb09f483e553a57072/cc_bindings_from_rs/generate_bindings/generate_struct_and_union.rs#L1950

Some pertinent documentation
https://github.com/google/crubit/blob/b4f9f89136dff9cef7dfa5fb09f483e553a57072/docs/design/unpin.md

## Background on trivial ABI

On Linux x86-64, GCC and Clang share both relevant specs: the System V AMD64 psABI for register-level parameter passing, and the Itanium C++ ABI for the C++ layer — name mangling, vtable layout, run time type info, exception handling, and the rules for how class types are passed, blah blah…

So you can link GCC and Clang objects together. For ordinary C++ this is a solved problem.

  The exception is trivial_abi
  ```[[clang::trivial_abi]]``` is a Clang extension that deliberately deviates from Itanium. 

Trivial ABI = POD types, structs of POD types with no user declared move/copy constructors or destructors.  In SysV AMD64 ABI this gets passed around in registers.

e.g. 
```
struct Point {
	double x;
	double y;
};
```

Non Trivial ABI = has a user defined non-trivial move constructor, copy constructor or destructor.  This has to be passed around in memory.

e.g. 
```
  class Owner {
   public:
    explicit Owner(std::string label) : label_(std::move(label)) {}
    ~Owner();                    // non-trivial destructor
   private:
    std::string label_;          // and a non-trivial copy/move
  };
```
Forced trivial ABI = In clang, there is an attribute you can use that forces cheap types to be passed around in registers .  The example below gets classified as non-trivial ABI because it has a user defined destructor but actually all it is is a wrapper around a pointer so there’s no reason why it needs memory allocation.  The attribute pushes it into a register pass.

e.g.
```
  class [[clang::trivial_abi]] Handle {
   public:
    ~Handle() { delete p_; }     // would normally force it into category 2
   private:
    Impl* p_;                    // ...but it's really just one pointer
  };
```

Between GCC and Clang this could be an issue because it changes the agreement on who owns the object lifetime.  Things passed by register in Clang are destroyed by the callee and things passed by memory are destroyed by the caller.  If you change an object from memory (compiled by gcc) to register (compiled by clang) over a boundary then an attempt to read it will point to the wrong place and a double free or memory leak could happen.

## This isn’t a problem for us because we’re going to build everything with gcc…


## Is it possible it would be a problem for some prebuilt objects or tools?  Is mixing binaries built with different tool chains a thing?


## It looks like this isn’t a problem (gigantic question mark)

Crubit, afaics, never passes these types by value across a boundary.  But then if that's true I'm not sure why trivial ABI is explicitly marked.

https://github.com/google/crubit/blob/main/cc_bindings_from_rs/generate_bindings/generate_function_thunk.rs#L185
I’m looking at this comment here -> “Types which are not C-ABI compatible by-value are returned via out-pointer parameters.”

There’s some shenanigans going on here that I’m not sure I can parse
https://github.com/google/crubit/blob/main/cc_bindings_from_rs/generate_bindings/generate_function_thunk.rs#L155

Does this apply to all non-trivial type passes? Uncle AI reckons yes but I wanted to check it’s a guaranteed thing by design.

I did get a tiny non trivial ABI example working and nothing exploded.  I’m only concerning myself with Linux and MacOS though...
